### PR TITLE
changed role attribute on images

### DIFF
--- a/source/_image.erb
+++ b/source/_image.erb
@@ -2,5 +2,5 @@
   <% breakpoints.each do |bp| %>
     <source media="<%= bp[:media_query] %>" srcset="<%= data.url + "?w=" + bp[:width].to_s %>">
   <% end %>
-  <img src="<%= data.url + "?w=" + breakpoints[0][:width].to_s %>" alt="<%= data.description %>" role="img">
+  <img src="<%= data.url + "?w=" + breakpoints[0][:width].to_s %>" alt="<%= data.description %>" role="presentation">
 </picture>


### PR DESCRIPTION
- Changed the 'role' attribute on decorative images to "presentation" as this role is not read out by screenreaders but allows the alt text still to be displayed to users when basic/broken html is displayed.