### PR TITLE
Moved 'skip to main content' link

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -44,12 +44,13 @@
   <%= stylesheet_link_tag "site" %>
 </head>
 <body class="govuk-template__body">
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 <div role="region">
 <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
 </div>
 <%= partial "cookie_banner" %>
+
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
   <%= partial "header", :locals => { :data => data } %>
 


### PR DESCRIPTION
- Moved the 'skip to main content' link to below the cookies banner as per ticket [26110](https://dfe-gov-uk.visualstudio.com.mcas.ms/Teach%20in%20Further%20Education/_workitems/edit/79483?McasTsid=26110).