### PR TITLE
adjusted the cookies confirmation to pull focus

### DIFF
--- a/js/consent.js
+++ b/js/consent.js
@@ -107,12 +107,14 @@ export class Consent {
 
     consentAccepted(id, showBannerOnNextPage = false) {
         document.getElementById(Consent.cookieAcceptanceBannerId).style.display = 'block'
+        document.getElementById(Consent.cookieAcceptanceBannerId).focus()
         this.enableCookies();
         this.saveConsentPreferences(id,{ isGranted: true, confirmationHidden: !showBannerOnNextPage })
     }
 
     consentRejected(id, showBannerOnNextPage = false) {
         document.getElementById(Consent.cookieRejectionBannerId).style.display = 'block'
+        document.getElementById(Consent.cookieRejectionBannerId).focus()
         this.removeCookies()
         this.saveConsentPreferences(id,{ isGranted: false, confirmationHidden: !showBannerOnNextPage })
     }

--- a/source/_cookie_acceptance.erb
+++ b/source/_cookie_acceptance.erb
@@ -1,17 +1,18 @@
-  <div id="cookie-banner-accepted" class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on teach in further education">
+  <div id="cookie-banner-accepted" class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on Teach in Further Education - Confirmation" tabindex="-1">
     <div class="govuk-cookie-banner__message govuk-width-container">
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
           <div class="govuk-cookie-banner__content">
-            <p class="govuk-body">You’ve accepted cookies. You can <a class="govuk-link" href="/cookies.html">change your cookie settings</a> at any time.</p>
+            <p class="govuk-body" tabindex="-1">
+            You’ve accepted cookies. You can <a class="govuk-link" href="/cookies.html">change your cookie settings</a> at any time.</p>
           </div>
         </div>
       </div>
 
       <div class="govuk-button-group">
-        <a href="#" role="button" draggable="false" class="govuk-button" onclick="window.site.consent.hideCookieConfirmation('cookie-banner-accepted')" data-module="govuk-button">
+        <a href="#" role="button" draggable="false" class="govuk-button" tabindex="-1" onclick="window.site.consent.hideCookieConfirmation('cookie-banner-accepted')" data-module="govuk-button">
           Hide this message
         </a>
       </div>

--- a/source/_cookie_rejection.erb
+++ b/source/_cookie_rejection.erb
@@ -1,17 +1,18 @@
-  <div id="cookie-banner-rejected" class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on teach in further education">
+  <div id="cookie-banner-rejected" class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on Teach in Further Education - Confirmation" tabindex="-1">
     <div class="govuk-cookie-banner__message govuk-width-container">
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
           <div class="govuk-cookie-banner__content">
-            <p class="govuk-body">You’ve rejected cookies. You can <a class="govuk-link" href="/cookies.html">change your cookie settings</a> at any time.</p>
+            <p class="govuk-body" tabindex="-1">
+            You’ve rejected cookies. You can <a class="govuk-link" href="/cookies.html">change your cookie settings</a> at any time.</p>
           </div>
         </div>
       </div>
 
       <div class="govuk-button-group">
-        <a href="#" role="button" draggable="false" class="govuk-button" onclick="window.site.consent.hideCookieConfirmation('cookie-banner-rejected')" data-module="govuk-button">
+        <a href="#" role="button" draggable="false" class="govuk-button" tabindex="-1" onclick="window.site.consent.hideCookieConfirmation('cookie-banner-rejected')" data-module="govuk-button">
           Hide this message
         </a>
       </div>


### PR DESCRIPTION
- Added focus action to the JS file for showing the confirmation banners
- Added tab index selectors to the relevant elements in the banners
- Changed the aria label on the confirmation banner to include 'confirmation' to differentiate from the original banner.