### PR TITLE
changed the error handling to be more concise for screenreaders

### DIFF
--- a/source/_question.erb
+++ b/source/_question.erb
@@ -2,11 +2,7 @@
   <div id="error-box" class="govuk-error-summary govuk-visually-hidden" role="alert" tabindex="-1">
       <h2 class="govuk-error-summary__title" id="error-summary-heading">
         There is a problem
-        <%# Error: <%= data.question_error_message %>
       </h2>
-      <p class="govuk-error-summary__body" tabindex="-1">
-        Error message
-      </p>
       <p class="govuk-list govuk-error-summary__list" tabindex="-1">
         <a href="#<%= "question-" + data.id %>" aria-label="Error: <%= data.question_error_message %>">
         <%= data.question_error_message %></a>
@@ -37,14 +33,11 @@
               <span id="error-message" class="govuk-error-message govuk-visually-hidden">
                 <span class="govuk-visually-hidden">Error:</span> <%= data.question_error_message %>
               </span>
-            <%# <span id="error-message" class="govuk-error-message govuk-visually-hidden">
-              <span class="govuk-visually-hidden" role="Alert">Error:</span> <%= data.question_error_message %>
-            <%# </span> %>
             <div class="govuk-radios" role="radiogroup" aria-labelledby="question-label">
               <% data.answers.each_with_index do |a,i| %>
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="<%= a.id %>-answer" name="answer" type="radio" value="<%= a.link.slug %>" aria-label="<%= a.answer %>" role="radio">
-                  <label class="govuk-label govuk-radios__label" id="<%= a.id %>_label" for="<%= a.id %>-answer" aria-hidden="true">
+                  <input class="govuk-radios__input" id="<%= a.id %>_answer" name="answer" type="radio" value="<%= a.link.slug %>" aria-label="<%= a.answer %>" role="radio">
+                  <label class="govuk-label govuk-radios__label" id="<%= a.id %>_label" for="<%= a.id %>_answer" aria-hidden="true">
                     <%= a.answer %>
                   </label>   
                 </div>
@@ -58,8 +51,8 @@
               <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                 <% data.answers.each_with_index do |a,i| %>
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="<%= a.id %>" name="answer" type="checkbox" value="<%= a.link.slug %>" aria-label="<%= a.answer %>">
-                    <label class="govuk-label govuk-checkboxes__label" id="<%= a.id %>_label" for="<%= a.id %>answer" aria-hidden="true">
+                    <input class="govuk-checkboxes__input" id="<%= a.id %>_answer" name="answer" type="checkbox" value="<%= a.link.slug %>" aria-label="<%= a.answer %>">
+                    <label class="govuk-label govuk-checkboxes__label" id="<%= a.id %>_label" for="<%= a.id %>_answer" aria-hidden="true">
                       <%= a.answer %>
                     </label>
                   </div>


### PR DESCRIPTION
Changed how screenreaders announce the error messages by:

- Removed the 'error message' text within the error summary component
- Removed the 'error' announcement from the error summary title
- Cleaned up a couple of id's which were not formatted in the correct way