### PR TITLE
changes to the home page nav

### DIFF
--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -7,7 +7,7 @@ describe 'Navigation', :type => :feature do
 
   it 'Has the correct page links' do
       within 'header' do
-      link = page.find_link("Home", match: :first)
+      link = page.find_link("Teach in further education", match: :first)
         within link do
           expect(link[:href]).to end_with '/'
       end


### PR DESCRIPTION
- Changes the home page link from 'home' to 'Teach in further education' site heading link